### PR TITLE
Add missing "copier copy" subcommand in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a [copier](https://copier.readthedocs.io/en/stable/) template for creati
 2. Run copier:
 
    ```bash
-   copier gh:nf-core/modules-template ./my-new-modules-library
+   copier copy gh:nf-core/modules-template ./my-new-modules-library
    ```
 
 3. Follow the prompts to fill in the template values.


### PR DESCRIPTION
See also https://seqera.io/blog/building-an-nf-core-style-modules-library/, which does recommend "copier copy".