### PR TITLE
Bump version

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,5 +2,5 @@
 name = "cz_gitmoji"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.1.0"
+version = "0.2.0"
 update_changelog_on_bump = true

--- a/.cz.toml
+++ b/.cz.toml
@@ -2,5 +2,5 @@
 name = "cz_gitmoji"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.2.0"
+version = "1.0.0"
 update_changelog_on_bump = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 0.2.0 (2025-07-15)
+## 0.2.0 (2026-01-13)
 
 ### ✨ Features
 
 - add repo host and ci customizability
-- add repo host and ci customizability
-- add repo host and ci customizability
+- all latest features and capabilities from upstream nf-core/modules
 
 ### 🐛🚑️ Fixes
 
@@ -20,7 +19,7 @@
 
 ### 🚀 Deployments
 
-- migrate project to nf-core
+- migrate repository to nf-core
 
 ## 0.1.0 (2024-10-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.2.0 (2025-07-15)
+
+### ✨ Features
+
+- add repo host and ci customizability
+- add repo host and ci customizability
+- add repo host and ci customizability
+
+### 🐛🚑️ Fixes
+
+- correct repo name in README
+
+### 💚👷 CI & Build
+
+- fix nf-test ci tags
+
+### 📸 Snapshots
+
+- remove snapshot stub tests in examplemodule
+
+### 🚀 Deployments
+
+- migrate project to nf-core
+
 ## 0.1.0 (2024-10-22)
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,22 @@
-## 0.2.0 (2026-01-13)
+## 1.0.0 (2026-01-14)
 
 ### ✨ Features
 
+- repository now at the nf-core GitHub organisation
 - add repo host and ci customizability
-- all latest features and capabilities from upstream nf-core/modules
+- all latest features and capabilities from upstream nf-core/modules, incl.
+  - support for nf-test
+  - nf-test CI (with sharding) on GitHub
+  - updated JSON schemas for modules and sub-workflows
+  - support for linting with topic channels
+  - updated DevContainer and VSCode support
+  - updated linter configuration (prek, etc)
+  - issue templates (for GitHub users)
 
 ### 🐛🚑️ Fixes
 
 - correct repo name in README
-
-### 💚👷 CI & Build
-
-- fix nf-test ci tags
-
-### 📸 Snapshots
-
-- remove snapshot stub tests in examplemodule
-
-### 🚀 Deployments
-
-- migrate repository to nf-core
+- placeholder and template values for copier
 
 ## 0.1.0 (2024-10-22)
 


### PR DESCRIPTION
Closes #2 (copier is very picky when using remote git repositories). After that we can make the 0.2.0 release on GitHub

Do not merge until #5 is merged, so that all the features are included